### PR TITLE
Submodule https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cmake"]
 	path = cmake
-	url = git@github.com:embedded-office/cmake-scripts.git
+	url = https://github.com/embedded-office/cmake-scripts.git


### PR DESCRIPTION
First of all thank you very much for open sourcing the stack. Run into a minor hurdle when I tried to evaluate the canopen-stack.

git submodule update failed with "Host key verification failed". It seems to be the better option to rely on https instead of ssh for submodules [https://stackoverflow.com/a/53855383](https://stackoverflow.com/a/53855383).

Cheers,
Sandro